### PR TITLE
a11y(ui): aria-controls on toggles; aria-live/aria-busy for dynamic lists; backend status role [v0.3.1]

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -285,6 +285,7 @@ async function loadDocs() {
     const data = await resp.json();
     if (!resp.ok) throw new Error(data.detail || 'Không tải được danh sách tài liệu');
 if (docList) {
+      try { docList.setAttribute('aria-busy', 'true'); } catch {}
       docList.innerHTML = '';
       let docs = data.docs || [];
       const term = (docFilter && docFilter.value || '').trim().toLowerCase();
@@ -309,6 +310,7 @@ const span = document.createElement('span'); span.className = 'title'; span.text
       const totalChunks = docs.reduce((s, it) => s + (parseInt(it.chunks, 10) || 0), 0);
       const name = (dbSelect && dbSelect.value) || 'default';
       if (dbStatus) dbStatus.textContent = `DB '${name}' — ${totalDocs} tài liệu, ${totalChunks} chunks`;
+      try { docList.setAttribute('aria-busy', 'false'); } catch {}
     }
   } catch (e) {
     console.error('loadDocs error', e);
@@ -597,6 +599,7 @@ async function loadAnalytics() {
     if (anAnsMed) anAnsMed.textContent = data.answer_len_median == null ? '-' : String(data.answer_len_median);
     const renderList = (el, arr) => {
       if (!el) return;
+      try { el.setAttribute('aria-busy', 'true'); } catch {}
       el.innerHTML = '';
       const id = el.id || '';
       const prefix = id === 'an-top-sources' ? '📄 ' : id === 'an-top-versions' ? '🏷️ ' : id === 'an-top-langs' ? '🌐 ' : '';
@@ -605,6 +608,7 @@ async function loadAnalytics() {
         li.textContent = `${prefix}${it.value} (${it.count})`;
         el.appendChild(li);
       });
+      try { el.setAttribute('aria-busy', 'false'); } catch {}
     };
     renderList(anTopSources, data.top_sources || []);
     renderList(anTopVersions, data.top_versions || []);

--- a/web/index.html
+++ b/web/index.html
@@ -34,7 +34,7 @@
 <button id="btn-reload" class="btn" title="Tải lại danh sách DB, tài liệu và hội thoại">🔄 Tải lại</button>
 <button id="btn-chat-export-db-json" class="btn" title="Xuất toàn bộ hội thoại của DB thành ZIP (JSON)">📦 Export DB (ZIP)</button>
           <span id="db-status" class="status"></span>
-          <span id="backend-status" class="status"></span>
+<span id="backend-status" class="status" role="status" aria-live="polite"></span>
         </div>
       </div>
       <!-- Global progress bar -->
@@ -47,10 +47,10 @@
         <!-- Sidebar -->
         <aside class="sidebar">
 <div class="panel">
-            <div class="panel-title">📄 Tài liệu trong DB (doc_id): <button id="btn-docs-toggle" class="btn" title="Thu gọn/mở rộng" aria-expanded="false">▾</button></div>
+            <div class="panel-title">📄 Tài liệu trong DB (doc_id): <button id="btn-docs-toggle" class="btn" title="Thu gọn/mở rộng" aria-expanded="false" aria-controls="docs-body">▾</button></div>
             <div id="docs-body" hidden>
               <input id="doc-filter" class="control" type="text" placeholder="Lọc tài liệu (từ khóa)" title="Lọc theo từ khóa trong đường dẫn nguồn" />
-              <ul id="doc-list" class="list"></ul>
+              <ul id="doc-list" class="list" aria-live="polite"></ul>
               <div class="panel-actions">
                 <button id="btn-docs-delete" class="btn danger">🗑️ Xóa tài liệu đã chọn</button>
               </div>
@@ -62,19 +62,19 @@
           </div>
 
 <div class="panel">
-            <div class="panel-title">💬 Lịch sử hội thoại: <button id="btn-chats-toggle" class="btn" title="Thu gọn/mở rộng" aria-expanded="false">▾</button></div>
+            <div class="panel-title">💬 Lịch sử hội thoại: <button id="btn-chats-toggle" class="btn" title="Thu gọn/mở rộng" aria-expanded="false" aria-controls="chats-body">▾</button></div>
             <div id="chats-body" hidden>
               <input id="chat-filter" class="control" type="text" placeholder="Lọc hội thoại (tên)" title="Lọc theo tên hội thoại" />
-              <ul id="chat-list" class="list"></ul>
+              <ul id="chat-list" class="list" aria-live="polite"></ul>
               <!-- Hidden select to keep compatibility with existing JS logic -->
               <select id="chat-select" style="display:none;"></select>
             </div>
           </div>
 
 <div class="panel">
-            <div class="panel-title">📊 Thống kê nhanh <button id="btn-stats-toggle" class="btn" title="Thu gọn/mở rộng">▾</button></div>
+            <div class="panel-title">📊 Thống kê nhanh <button id="btn-stats-toggle" class="btn" title="Thu gọn/mở rộng" aria-expanded="true" aria-controls="stats-body">▾</button></div>
             <div id="stats-body">
-            <div class="stats-grid">
+            <div class="stats-grid" aria-live="polite">
               <div class="stat"><span class="muted">Chats</span> <strong id="an-chats">-</strong></div>
               <div class="stat"><span class="muted">Q/A</span> <strong id="an-qa">-</strong></div>
               <div class="stat"><span class="muted">Đã trả lời</span> <strong id="an-answered">-</strong></div>
@@ -83,11 +83,11 @@
               <div class="stat"><span class="muted">Median</span> <strong id="an-ans-med">-</strong></div>
             </div>
             <div class="panel-title muted" style="margin-top:6px">Nguồn nhiều nhất</div>
-            <ul id="an-top-sources" class="list"></ul>
+            <ul id="an-top-sources" class="list" aria-live="polite"></ul>
             <div class="panel-title muted" style="margin-top:6px">Phiên bản nhiều nhất</div>
-            <ul id="an-top-versions" class="list"></ul>
+            <ul id="an-top-versions" class="list" aria-live="polite"></ul>
             <div class="panel-title muted" style="margin-top:6px">Ngôn ngữ nhiều nhất</div>
-            <ul id="an-top-langs" class="list"></ul>
+            <ul id="an-top-langs" class="list" aria-live="polite"></ul>
             </div>
           </div>
         </aside>


### PR DESCRIPTION
Accessibility polish:\n- Add aria-controls to Docs/Chats/Stats toggle buttons\n- Add aria-live=polite and aria-busy to dynamic lists (Docs, Analytics Top lists); stats grid uses aria-live\n- backend-status uses role=status + aria-live=polite to announce changes\n\nNo functional changes; pytest: 34 passed locally.\n\nMilestone: v0.3.1\nRelated: #16